### PR TITLE
Update to Cake 0.37.0

### DIFF
--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.35.0" />
+    <package id="Cake" version="0.37.0" />
 </packages>


### PR DESCRIPTION
Update to Cake 0.37.0 which fixes failing build on Ubunut (https://github.com/cake-build/cake/issues/2695)